### PR TITLE
Numpy 1.9 on my Centos build chops int64s into two int32s

### DIFF
--- a/pysrc/cellh5write.py
+++ b/pysrc/cellh5write.py
@@ -260,9 +260,10 @@ class CH5RegionWriter(CH5ObjectWriter):
             
             
         object_labels = object_labels.astype(numpy.int32)
-        times = numpy.repeat(t, len(object_labels))
+        times = numpy.repeat(t, len(object_labels)).astype(numpy.int32)
         
-        self.dset[self.offset:self.offset+len(object_labels)] = numpy.c_[times, object_labels].view(dtype=self.dtype).T
+        self.dset[self.offset:self.offset+len(object_labels)] = \
+            numpy.c_[times, object_labels].view(dtype=self.dtype).T
         
         self.offset+=len(object_labels)
         
@@ -401,8 +402,8 @@ class CH5ImageWideObjectWriter(CH5ObjectWriter):
         if 1 + self.offset > len(self.dset) :
             # resize
             self.dset.resize((1 + self.offset,))
-                    
-        self.dset[self.offset:self.offset+1] = numpy.array([self.offset, t,c,z]).view(dtype=self.dtype).T
+        src = numpy.array([[self.offset, t,c,z]], numpy.int32).view(dtype=self.dtype)
+        self.dset[self.offset:self.offset+1] = src
         
         self.offset+=1
     


### PR DESCRIPTION
This bug fixes some problems I'm seeing on our Linux build. I'm not sure if this is a change in behavior in Numpy 1.9 or is something caused by differences in the way the arrays are built. The basic problem is this construct:

    > import numpy
    > dtype = numpy.dtype([("A", "int32", "B", "int32")])
    > a = numpy.array([[1, 2]], int).view(dtype)
    > a.shape
    (2, 1)

The problem is that "view" looks at the buffer, `(0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,)` and looks at the dtype which is two integers at four bytes apiece and carves the 16 bytes above into two 8 byte rows. The solution is to explicitly type arrays as numpy.int32 when this construct is used.